### PR TITLE
Get access_token from headers, body and query.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -15,12 +15,12 @@ function Strategy(options, verify) {
 	if (options.authType !== undefined) options.authorizationURL += '&auth_type=' + options.authType;
 	options.tokenURL = options.tokenURL || 'https://nid.naver.com/oauth2.0/token';
 
-    options.scopeSeparator = options.scopeSeparator || ',';
-    options.customHeaders = options.customHeaders || {};
+	options.scopeSeparator = options.scopeSeparator || ',';
+	options.customHeaders = options.customHeaders || {};
 
-    if (!options.customHeaders['User-Agent']) {
-        options.customHeaders['User-Agent'] = options.userAgent || 'passport-naver';
-    }
+	if (!options.customHeaders['User-Agent']) {
+		options.customHeaders['User-Agent'] = options.userAgent || 'passport-naver';
+	}
 
 	OAuth2Strategy.call(this, options, verify);
 	this.name = 'naver-token';
@@ -28,7 +28,7 @@ function Strategy(options, verify) {
 	this._refreshTokenField = options.refreshTokenField || 'refresh_token';
 	this._passReqToCallback = options.passReqToCallback || false;
 	delete this._oauth2._clientSecret;
-};
+}
 /**
  * Inherit from `OAuthStrategy`.
  */
@@ -39,9 +39,15 @@ util.inherits(Strategy, OAuth2Strategy);
  * Inherit from `OAuthStrategy`.
  */
 Strategy.prototype.authenticate = function (req, options) {
-	var accessToken = req.query[this._accessTokenField];
-	var refreshToken = req.query[this._refreshTokenField];
+
+	// assign default value to make sure next command can work well
+	req.body = req.body || {};
+	req.query = req.query || {};
+	req.headers = req.headers || {};
+
 	var self = this;
+	var accessToken = req.body[this._accessTokenField] || req.query[this._accessTokenField] || req.headers[this._accessTokenField];
+	var refreshToken = req.body[this._refreshTokenField] || req.query[this._refreshTokenField] || req.headers[this._refreshTokenField];
 
 	if (!accessToken) return this.fail({message: 'You should provide ${this._accessTokenField}'});
 
@@ -78,9 +84,10 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 		try {
 			var json = JSON.parse(body);
 			var profile = { provider: 'naver' };
+
 			profile.id = json.response.id;
 			profile.name = json.response.name;
-            profile.email = json.response.email;
+			profile.email = json.response.email;
 			profile.nickName = json.response.nickName;
 			profile.enc_id = json.response.enc_id;
 			profile.profile_image = json.response.profile_image;


### PR DESCRIPTION
If access_token contains `+` we can not using GET method, cause it will change + to ' '. So I added two more options that help to pass access_token via headers and body.